### PR TITLE
Fix Download Behind Proxy

### DIFF
--- a/lib/mix/tasks/compile.nerves_toolchain.ex
+++ b/lib/mix/tasks/compile.nerves_toolchain.ex
@@ -61,11 +61,10 @@ defmodule Mix.Tasks.Compile.NervesToolchain do
 
   defp cache(:github, params) do
     Mix.shell.info "Downloading from Github Cache"
-    Application.ensure_all_started(:httpoison)
 
     url = "https://github.com/nerves-project/nerves-toolchain/releases/download/v#{params.version}/nerves-#{params.target_tuple}-#{host_platform}-#{host_arch}-v#{params.version}.tar.xz"
-    case HTTPoison.get(url, [], follow_redirect: true, recv_timeout: @recv_timeout) do
-      {:ok, %{status_code: code, body: body}} when code in 200..299 -> body
+    case Mix.Utils.read_path(url) do
+      {:ok, body} -> body
       {_, error} ->
         raise "Nerves Toolchain Github cache returned error: #{inspect error}"
     end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule NervesToolchain.Mixfile do
   end
 
   defp deps do
-    [{:httpoison, "~> 0.8"}]
+    []
   end
 
   defp description do


### PR DESCRIPTION
This fixes the issue with trying to run behind a proxy server.

There is a long standing bug in Hackney (and thus HTTPoison) that prevents redirects from working correctly with a proxy server.  See edgurgel/httpoison#112.  

I tried fixing the bug upstream in hackney, but it is non-trivial.  Luckily, Mix already has a Utility function that accomplishes the same thing.  

I will create a similar pull request for nerves_system, as it has the same issue