### PR TITLE
First pass at Windows support

### DIFF
--- a/lib/mix/tasks/compile.nerves_toolchain.ex
+++ b/lib/mix/tasks/compile.nerves_toolchain.ex
@@ -21,8 +21,8 @@ defmodule Mix.Tasks.Compile.NervesToolchain do
     {:ok, _} = Application.ensure_all_started(toolchain)
 
     toolchain_config = Application.get_all_env(toolchain)
-    target_tuple = toolchain_config[:target_tuple] ||
-      raise "Target tuple required to be set in toolchain env"
+    target_tuple = toolchain_config[:target_tuple]
+    cache_url = toolchain_config[:cache_url]
 
     nerves_toolchain_config = Application.get_all_env(:nerves_toolchain)
     |> Enum.into(%{})
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.Compile.NervesToolchain do
     cache       = if is_binary(cache), do: String.to_atom(cache), else: cache
     build_path  = Mix.Project.build_path
                   |> Path.join(@dir)
-    params      = %{target_tuple: target_tuple, version: config[:version], build_path: build_path}
+    params      = %{target_tuple: target_tuple, cache_url: cache_url, version: config[:version], build_path: build_path}
 
     if stale?(build_path) do
       File.rm_rf!(build_path)
@@ -58,10 +58,23 @@ defmodule Mix.Tasks.Compile.NervesToolchain do
     end
   end
 
-  defp cache(:github, params) do
-    shell_info "Downloading Toolchain"
+  defp cache(:github, params=%{target_tuple: target_tuple}) when target_tuple != nil do
+    "https://github.com/nerves-project/nerves-toolchain/releases/download/v#{params.version}/nerves-#{params.target_tuple}-#{host_platform}-#{host_arch}-v#{params.version}.tar.xz"
+    |> download_url()
+  end
 
-    url = "https://github.com/nerves-project/nerves-toolchain/releases/download/v#{params.version}/nerves-#{params.target_tuple}-#{host_platform}-#{host_arch}-v#{params.version}.tar.xz"
+  defp cache(_, params=%{cache_url: cache_url}) when cache_url != nil do
+    cache_url
+    |> download_url()
+  end
+
+  defp cache(:none, params) do
+    compile(params)
+  end
+
+
+  defp download_url(url) do
+    shell_info "Downloading Toolchain"
     case Mix.Utils.read_path(url) do
       {:ok, body} ->
         shell_info "Toolchain Downloaded"
@@ -71,9 +84,7 @@ defmodule Mix.Tasks.Compile.NervesToolchain do
     end
   end
 
-  defp cache(:none, params) do
-    compile(params)
-  end
+
 
   defp compile(params) do
     Mix.shell.info "Starting Nerves Toolchain Build"
@@ -109,8 +120,7 @@ defmodule Mix.Tasks.Compile.NervesToolchain do
 
     tar_file = tmp_dir <> "/toolchain.tar.xz"
     File.write(tar_file, toolchain_tar)
-    System.cmd("tar", ["xf", tar_file], cd: tmp_dir)
-
+    extract_archive(tar_file,tmp_dir)
 
     source =
       File.ls!(tmp_dir)
@@ -121,6 +131,21 @@ defmodule Mix.Tasks.Compile.NervesToolchain do
     File.rm_rf!(tmp_dir)
     Path.join(dest, ".nerves.lock")
     |> File.touch
+  end
+
+  defp extract_archive(tar_file,tmp_dir) do
+    {_,os_type} = :os.type
+    extract_archive(os_type,tar_file,tmp_dir)
+  end
+
+  defp extract_archive(:nt,tarxz_file,tmp_dir) do
+    System.cmd("7z", ["x", tarxz_file], cd: tmp_dir)
+    tar_file = String.replace_suffix(tarxz_file,".xz","")
+    System.cmd("7z", ["x", tar_file], cd: tmp_dir)
+  end
+
+  defp extract_archive(_,tar_file,tmp_dir) do
+    System.cmd("tar", ["xf", tar_file], cd: tmp_dir)
   end
 
   def shell_info(text), do: Mix.shell.info "[nerves_toolchain][http] #{text}"


### PR DESCRIPTION
This PR address two issues:
- Allow specifying the full path to the cache (needed since there are no official Windows builds yet)
- Use 7zip instead of tar on Windows.  See nerves-project/nerves_system#5
